### PR TITLE
Implement destroy comment and add permission

### DIFF
--- a/comments/api/permissions.py
+++ b/comments/api/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsObjectOwner(BasePermission):
+    message = "You do not have permission to access this object"
+
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return request.user == obj.user

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -66,3 +66,9 @@ class CommentViewSet(viewsets.GenericViewSet):
             {'tweets': serializer.data},
             status=200
         )
+
+    def destroy(self, request, *args, **kwargs):
+        comment = self.get_object()
+        comment.delete()
+        return Response({'success': True}, status=200)
+


### PR DESCRIPTION
Delete a comment , only add `destroy()` function under the view
In the following example, logged in user id  = 11, and would like to delete tweet id = 6


<img width="1198" alt="image" src="https://github.com/yanlovescoding/MyTwitter/assets/79724590/f003fd81-c206-433b-b4a8-7c0f36a71bf5">

<img width="1201" alt="image" src="https://github.com/yanlovescoding/MyTwitter/assets/79724590/fdb43a2a-c825-477a-a4fb-dc88ead7a16c">

<img width="1194" alt="image" src="https://github.com/yanlovescoding/MyTwitter/assets/79724590/c1d620a1-01b9-4988-8b8f-2556cebc0f57">

